### PR TITLE
Html rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.5
 
 env:
-  - DEPS="pandas pytest traitlets pip"
+  - DEPS="pandas pytest traitlets pip jinja2"
 
 install:
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION

--- a/altair/html.py
+++ b/altair/html.py
@@ -1,0 +1,22 @@
+import os
+import jinja2
+import json
+
+def render(spec, width=None, height=None):
+	
+	from jinja2 import Template, escape
+
+	if width is None:
+		width = 500;
+	if height is None:
+		height = 300
+
+	location = os.path.join(os.path.dirname(__file__), 'templates/template.html')
+	base = open(location).read()
+	d = spec.to_dict()
+	d['config'] = {'width': width, 'height': height}
+	spec = escape(json.dumps(d))
+	fields = {'spec': spec, 'width': width, 'height': height}
+	t = Template(base)
+	html = t.render(**fields)
+	return html

--- a/altair/html.py
+++ b/altair/html.py
@@ -1,6 +1,7 @@
 import os
 import jinja2
 import json
+import numpy
 
 def render(spec, width=None, height=None):
 	
@@ -15,7 +16,14 @@ def render(spec, width=None, height=None):
 	base = open(location).read()
 	d = spec.to_dict()
 	d['config'] = {'width': width, 'height': height}
-	spec = escape(json.dumps(d))
+
+	class NumpyConvert(json.JSONEncoder):
+		def default(self, obj):
+			if isinstance(obj, numpy.generic):
+				return numpy.asscalar(obj)
+			return json.JSONEncoder.default(self, obj)
+
+	spec = escape(json.dumps(d, cls=NumpyConvert))
 	fields = {'spec': spec, 'width': width, 'height': height}
 	t = Template(base)
 	html = t.render(**fields)

--- a/altair/templates/template.html
+++ b/altair/templates/template.html
@@ -1,0 +1,31 @@
+
+<iframe width='{{ width }}' height='{{ height }}' frameBorder='0' srcdoc='
+<html>
+  <head>
+    <script src="http://vega.github.io/vega-editor/vendor/d3.min.js"></script>
+    <script src="http://vega.github.io/vega-editor/vendor/topojson.js"></script>
+    <script src="http://vega.github.io/vega-editor/vendor/d3.layout.cloud.js"></script>
+    <script src="http://rawgit.com/freeman-lab/vega-playground/master/js/vega.js"></script>
+    <script src="http://rawgit.com/freeman-lab/vega-playground/master/js/vega-lite.js"></script>
+  </head>
+  <body>  
+    <div id="vis"></div>
+  </body>
+    <script type="text/javascript">
+      console.log(vg)
+
+      function parse(spec) {
+        vg.parse.spec(spec, function(chart) { 
+          chart({el:"#vis"}).update(); 
+        });
+      }
+
+      function render(blob) {
+        var spec = vl.compile(blob);
+        parse(spec)
+      }
+      var data = {{ spec }}
+      render(data);
+    </script>
+</html>'
+</iframe>

--- a/altair/tests/test_html.py
+++ b/altair/tests/test_html.py
@@ -1,0 +1,10 @@
+from .. import api, spec, html
+
+
+def test_render():
+    data = dict(x=[1, 2, 3],
+                y=[4, 5, 6])
+    spec = api.Viz(data)
+    s = spec.encode(x='x:Q', y='y:Q').mark_line()
+    r = html.render(s)
+    assert r is not None

--- a/example-html-rendering.ipynb
+++ b/example-html-rendering.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from altair import api, html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = dict(x=[1, 2, 3], y=[1, 2, 3])\n",
+    "spec = api.Viz(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "s = spec.encode(x='x:Q', y='y:Q').mark_line()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import HTML, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe width='800' height='400' frameBorder='0' srcdoc='\n",
+       "<html>\n",
+       "  <head>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/d3.min.js\"></script>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/topojson.js\"></script>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/d3.layout.cloud.js\"></script>\n",
+       "    <script src=\"http://rawgit.com/freeman-lab/vega-playground/master/js/vega.js\"></script>\n",
+       "    <script src=\"http://rawgit.com/freeman-lab/vega-playground/master/js/vega-lite.js\"></script>\n",
+       "  </head>\n",
+       "  <body>  \n",
+       "    <div id=\"vis\"></div>\n",
+       "  </body>\n",
+       "    <script type=\"text/javascript\">\n",
+       "      console.log(vg)\n",
+       "\n",
+       "      function parse(spec) {\n",
+       "        vg.parse.spec(spec, function(chart) { \n",
+       "          chart({el:\"#vis\"}).update(); \n",
+       "        });\n",
+       "      }\n",
+       "\n",
+       "      function render(blob) {\n",
+       "        var spec = vl.compile(blob);\n",
+       "        parse(spec)\n",
+       "      }\n",
+       "      var data = {&#34;config&#34;: {&#34;width&#34;: 800, &#34;height&#34;: 800}, &#34;marktype&#34;: &#34;line&#34;, &#34;data&#34;: {&#34;formatType&#34;: &#34;json&#34;, &#34;values&#34;: [{&#34;y&#34;: 1, &#34;x&#34;: 1}, {&#34;y&#34;: 2, &#34;x&#34;: 2}, {&#34;y&#34;: 3, &#34;x&#34;: 3}]}, &#34;encoding&#34;: {&#34;y&#34;: {&#34;bin&#34;: false, &#34;type&#34;: &#34;Q&#34;, &#34;name&#34;: &#34;y&#34;}, &#34;x&#34;: {&#34;bin&#34;: false, &#34;type&#34;: &#34;Q&#34;, &#34;name&#34;: &#34;x&#34;}}}\n",
+       "      render(data);\n",
+       "    </script>\n",
+       "</html>'\n",
+       "</iframe>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "out = html.render(s)\n",
+    "display(HTML(out))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "unicode"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import HTML, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe width='800' height='400' frameBorder='0' srcdoc='\n",
+       "<html>\n",
+       "  <head>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/d3.min.js\"></script>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/topojson.js\"></script>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/d3.layout.cloud.js\"></script>\n",
+       "    <script src=\"http://rawgit.com/freeman-lab/vega-playground/master/js/vega.js\"></script>\n",
+       "    <script src=\"http://rawgit.com/freeman-lab/vega-playground/master/js/vega-lite.js\"></script>\n",
+       "  </head>\n",
+       "  <body>  \n",
+       "    <div id=\"vis\"></div>\n",
+       "  </body>\n",
+       "    <script type=\"text/javascript\">\n",
+       "      console.log(vg)\n",
+       "\n",
+       "      function parse(spec) {\n",
+       "        vg.parse.spec(spec, function(chart) { \n",
+       "          chart({el:\"#vis\"}).update(); \n",
+       "        });\n",
+       "      }\n",
+       "\n",
+       "      function render(blob) {\n",
+       "        var spec = vl.compile(blob);\n",
+       "        parse(spec)\n",
+       "      }\n",
+       "      var data = {&#34;config&#34;: {&#34;width&#34;: 800, &#34;height&#34;: 800}, &#34;marktype&#34;: &#34;line&#34;, &#34;data&#34;: {&#34;formatType&#34;: &#34;json&#34;, &#34;values&#34;: [{&#34;y&#34;: 1, &#34;x&#34;: 1}, {&#34;y&#34;: 2, &#34;x&#34;: 2}, {&#34;y&#34;: 3, &#34;x&#34;: 3}]}, &#34;encoding&#34;: {&#34;y&#34;: {&#34;bin&#34;: false, &#34;type&#34;: &#34;Q&#34;, &#34;name&#34;: &#34;y&#34;}, &#34;x&#34;: {&#34;bin&#34;: false, &#34;type&#34;: &#34;Q&#34;, &#34;name&#34;: &#34;x&#34;}}}\n",
+       "      render(data);\n",
+       "    </script>\n",
+       "</html>'\n",
+       "</iframe>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(HTML(foo))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/example-html-rendering.ipynb
+++ b/example-html-rendering.ipynb
@@ -102,6 +102,61 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe width='800' height='400' frameBorder='0' srcdoc='\n",
+       "<html>\n",
+       "  <head>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/d3.min.js\"></script>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/topojson.js\"></script>\n",
+       "    <script src=\"http://vega.github.io/vega-editor/vendor/d3.layout.cloud.js\"></script>\n",
+       "    <script src=\"http://rawgit.com/freeman-lab/vega-playground/master/js/vega.js\"></script>\n",
+       "    <script src=\"http://rawgit.com/freeman-lab/vega-playground/master/js/vega-lite.js\"></script>\n",
+       "  </head>\n",
+       "  <body>  \n",
+       "    <div id=\"vis\"></div>\n",
+       "  </body>\n",
+       "    <script type=\"text/javascript\">\n",
+       "      console.log(vg)\n",
+       "\n",
+       "      function parse(spec) {\n",
+       "        vg.parse.spec(spec, function(chart) { \n",
+       "          chart({el:\"#vis\"}).update(); \n",
+       "        });\n",
+       "      }\n",
+       "\n",
+       "      function render(blob) {\n",
+       "        var spec = vl.compile(blob);\n",
+       "        parse(spec)\n",
+       "      }\n",
+       "      var data = {&#34;config&#34;: {&#34;width&#34;: 800, &#34;height&#34;: 800}, &#34;marktype&#34;: &#34;line&#34;, &#34;data&#34;: {&#34;formatType&#34;: &#34;json&#34;, &#34;values&#34;: [{&#34;y&#34;: 1, &#34;x&#34;: 1}, {&#34;y&#34;: 2, &#34;x&#34;: 2}, {&#34;y&#34;: 3, &#34;x&#34;: 3}]}, &#34;encoding&#34;: {&#34;y&#34;: {&#34;bin&#34;: false, &#34;type&#34;: &#34;Q&#34;, &#34;name&#34;: &#34;y&#34;}, &#34;x&#34;: {&#34;bin&#34;: false, &#34;type&#34;: &#34;Q&#34;, &#34;name&#34;: &#34;x&#34;}}}\n",
+       "      render(data);\n",
+       "    </script>\n",
+       "</html>'\n",
+       "</iframe>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "out = html.render(s)\n",
+    "display(HTML(out))"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 14,
    "metadata": {
     "collapsed": false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 traitlets
 pandas
+jinja2

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(name=NAME,
       download_url=DOWNLOAD_URL,
       license=LICENSE,
       packages=PACKAGES,
-      install_requires=open('requirements.txt').read().split(),
       classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(name=NAME,
       download_url=DOWNLOAD_URL,
       license=LICENSE,
       packages=PACKAGES,
+      install_requires=open('requirements.txt').read().split(),
       classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
This PR adds simple rendering of the specification's generated by the API via html. Example usage looks like this (here we're targeting display in an IPython notebook):

```
from altair import api, html
from IPython.display import HTML, display

data = dict(x=[1, 2, 3], y=[1, 2, 3])
spec = api.Viz(data).encode(x='x:Q', y='y:Q').mark_line()
out = html.render(s)
display(HTML(out))
```

I included a pretty bare bones test `html`. Also the size handling needs some testing. But otherwise should be functional.