### PR TITLE
Update HTML rendering to Jinja template loader, setup.py to try setup…

### DIFF
--- a/altair/html.py
+++ b/altair/html.py
@@ -30,7 +30,9 @@ def render(spec, width=None, height=None):
     html : str
     """
 
-    from jinja2 import Template, escape
+    from jinja2 import Template, Environment, PackageLoader, escape
+
+    env = Environment(loader=PackageLoader('altair', 'templates'))
 
     if width is not None:
         spec.vlconfig.width = width
@@ -41,9 +43,7 @@ def render(spec, width=None, height=None):
     else:
         height = spec.vlconfig.height
 
-    location = os.path.join(os.path.dirname(__file__),
-                            'templates/template.html')
-    base = open(location).read()
+    template = env.get_template('template.html')
     d = spec.to_dict()
 
     class NumpyConvert(json.JSONEncoder):
@@ -54,8 +54,7 @@ def render(spec, width=None, height=None):
 
     spec = escape(json.dumps(d, cls=NumpyConvert))
     fields = {'spec': spec, 'width': width, 'height': height}
-    t = Template(base)
-    html = t.render(**fields)
+    html = template.render(**fields)
     return html
 
 def save(spec, fname, overwrite=False, width=None, height=None):
@@ -67,7 +66,7 @@ def save(spec, fname, overwrite=False, width=None, height=None):
     spec : altair.api.Viz object
         Represents the visualization spec to be rendered to html
 
-    fname : str 
+    fname : str
         Name of file to write to
 
     overwrite : boolean, optional, default=False

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,10 @@ import io
 import os
 import re
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 def read(path, encoding='utf-8'):


### PR DESCRIPTION
A couple small things:

* Jinja has a *really* nice template loader that we can leverage. Since we've already got the dependency, might as well use it. 
* I really, really like trying to import `setuptools` with a fallback to `distutils`. Without `setuptools`, you can't do things like `python setup.py develop`, which make iterate workflow pretty tough. 

All tests passing :+1: 