### PR TITLE
Remove boilerplate from API

### DIFF
--- a/altair/api.py
+++ b/altair/api.py
@@ -209,12 +209,12 @@ class OrderChannel(_ChannelMixin, schema.OrderChannelDef):
 
 
 class Order(OrderChannel):
-    channel_name = 'detail'
+    channel_name = 'order'
 
 
 class Path(OrderChannel):
     channel_name = 'path'
-    
+
 
 #*************************************************************************
 # Aliases
@@ -389,6 +389,9 @@ class Layer(schema.BaseObject):
             if item.channel_name in kwargs:
                 raise ValueError('Mulitple value for {0} provided'.format(item.channel_name))
             kwargs[item.channel_name] = item
+        for key, val in kwargs.items():
+            if not isinstance(val, CHANNEL_CLASSES[key]):
+                kwargs[key] = CHANNEL_CLASSES[key](val)
         self.encoding = Encoding(**kwargs)
         return self
 

--- a/altair/api.py
+++ b/altair/api.py
@@ -385,13 +385,14 @@ class Layer(schema.BaseObject):
 
     def encode(self, *args, **kwargs):
         """Define the encoding for the Layer."""
+        for key, val in kwargs.items():
+            if key in CHANNEL_CLASSES:
+                if not isinstance(val, CHANNEL_CLASSES[key]):
+                    kwargs[key] = CHANNEL_CLASSES[key](val)
         for item in args:
             if item.channel_name in kwargs:
                 raise ValueError('Mulitple value for {0} provided'.format(item.channel_name))
             kwargs[item.channel_name] = item
-        for key, val in kwargs.items():
-            if not isinstance(val, CHANNEL_CLASSES[key]):
-                kwargs[key] = CHANNEL_CLASSES[key](val)
         self.encoding = Encoding(**kwargs)
         return self
 


### PR DESCRIPTION
This is a tiny change in the top-level API that makes for less boilerplate. Using the scatterplot example, the current API looks like this:

```python
Layer(data).encode(
    X('Horsepower'),
    Y('Miles_per_Gallon'),
    Color('Origin'),
    Size('Weight_in_lbs')
).point()
```
You can also use keywords, e.g.
```python
Layer(data).encode(
    x=X('Horsepower'),
    y=Y('Miles_per_Gallon'),
    color=Color('Origin'),
    size=Size('Weight_in_lbs')
).point()
```

With this PR, there is a (to my mind) more intuitive way to do this:

```python
Layer(data).encode(
    x='Horsepower',
    y='Miles_per_Gallon',
    color='Origin',
    size='Weight_in_lbs'
).point()
```

The string arguments are converted automatically to the appropriate object. Note that this works only in the ``encode()`` function, not deeper within the object hierarchy.

What do you think?