### PR TITLE
[MRG] enhance configure() and add data_transform() method

### DIFF
--- a/altair/api.py
+++ b/altair/api.py
@@ -422,7 +422,7 @@ class Layer(schema.BaseObject):
         self.config.update_traits(**kwargs)
         return self
 
-    def data_transform(self, **kwargs):
+    def transform_data(self, **kwargs):
         """Set the Data Transform"""
         if self.transform is None:
             self.transform = schema.Transform()

--- a/altair/api.py
+++ b/altair/api.py
@@ -392,7 +392,9 @@ class Layer(schema.BaseObject):
             if item.channel_name in kwargs:
                 raise ValueError('Mulitple value for {0} provided'.format(item.channel_name))
             kwargs[item.channel_name] = item
-        self.encoding = Encoding(**kwargs)
+        if self.encoding is None:
+            self.encoding = Encoding()
+        self.encoding.update_traits(**kwargs)
         return self
 
     def configure(self, *args, **kwargs):
@@ -403,7 +405,7 @@ class Layer(schema.BaseObject):
                          if isinstance(val, T.Instance)}
         trait_to_name = {v:k for k, v in name_to_trait.items()}
 
-        if len(name_to_trait) == len(trait_to_name):
+        if len(name_to_trait) != len(trait_to_name):
             raise ValueError("Two Config() traits have the same class. "
                              "(Possibly caused by a vega-lite schema update?)")
 
@@ -415,14 +417,16 @@ class Layer(schema.BaseObject):
                 kwargs[key] = val
             else:
                 raise ValueError("unrecognized argument: {0}".format(val))
-        self.config = schema.Config(**kwargs)
+        if self.config is None:
+            self.config = schema.Config()
+        self.config.update_traits(**kwargs)
         return self
 
-    def data_transform(self, calculate=None, filter=None,
-                       filterNull=None, **kwargs):
+    def data_transform(self, **kwargs):
         """Set the Data Transform"""
-        self.transform = schema.Transform(calculate=calculate, filter=filter,
-                                          filterNull=filterNull, **kwargs)
+        if self.transform is None:
+            self.transform = schema.Transform()
+        self.transform.update_traits(**kwargs)
         return self
 
     def mark_area(self):

--- a/altair/schema/baseobject.py
+++ b/altair/schema/baseobject.py
@@ -49,6 +49,11 @@ class BaseObject(T.HasTraits):
                     result[k] = trait_to_dict(v)
         return result
 
+    def update_traits(self, **kwargs):
+        for key, val in kwargs.items():
+            self.set_trait(key, val)
+        return self
+
 
 def trait_to_dict(obj):
     """Recursively convert object to dictionary"""

--- a/altair/tests/test_api.py
+++ b/altair/tests/test_api.py
@@ -1,0 +1,37 @@
+import pytest
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from .. import Layer, Formula, MarkConfig
+from ..utils import parse_shorthand, infer_vegalite_type
+
+
+def test_encode_update():
+    # Test that encode updates rather than overwrites
+    layer1 = Layer().encode(x='blah:Q').encode(y='blah:Q')
+    layer2 = Layer().encode(x='blah:Q', y='blah:Q')
+
+    assert layer1.to_dict() == layer2.to_dict()
+
+
+def test_configure_update():
+    # Test that configure updates rather than overwrites
+    layer1 = Layer().configure(MarkConfig(color='red'))\
+                    .configure(background='red')
+    layer2 = Layer().configure(MarkConfig(color='red'), background='red')
+
+    assert layer1.to_dict() == layer2.to_dict()
+
+
+def test_transform_update():
+    # Test that transform updates rather than overwrites
+    formula = Formula(field='gender', expr='datum.sex == 2 ? "Female":"Male"')
+    layer1 = Layer().data_transform(filter='datum.year==2000')\
+                    .data_transform(calculate=[formula])
+
+    layer2 = Layer().data_transform(filter='datum.year==2000',
+                                    calculate=[formula])
+
+    assert layer1.to_dict() == layer2.to_dict()

--- a/altair/tests/test_api.py
+++ b/altair/tests/test_api.py
@@ -28,10 +28,10 @@ def test_configure_update():
 def test_transform_update():
     # Test that transform updates rather than overwrites
     formula = Formula(field='gender', expr='datum.sex == 2 ? "Female":"Male"')
-    layer1 = Layer().data_transform(filter='datum.year==2000')\
-                    .data_transform(calculate=[formula])
+    layer1 = Layer().transform_data(filter='datum.year==2000')\
+                    .transform_data(calculate=[formula])
 
-    layer2 = Layer().data_transform(filter='datum.year==2000',
+    layer2 = Layer().transform_data(filter='datum.year==2000',
                                     calculate=[formula])
 
     assert layer1.to_dict() == layer2.to_dict()


### PR DESCRIPTION
Two additions to the API here:

### configuration

 First, ``configure()`` is enhanced to handle arguments similarly to ``encode()``. So you can do

```python
Layer(data).configure(MarkConfig(color='red'))
```
as a shorthand for
```python
Layer(data).configure(mark=MarkConfig(color='red'))
```

### transformation
Secondly, I added the ``data_transform()`` method similar to ``configure()`` and ``encode()``, so you can do this:
```python
population = load_dataset('population')
Layer(data).data_transform(
        filter="datum.year==2000"
    )
```
in place of the current approach:
```python
Layer(data, transform=Transform(filter="datum.year==2000"))
```

I realize ``data_transform`` is a bit awkward/redundant. This really should be called ``transform``, but that is already used as an attribute name in vega-lite. IMHO, it would be more consistent if the attribute were ``transformation`` and the action were ``transform``, but we can't control everything :smile: