### PR TITLE
ENH: add traitlet tab completion hack

### DIFF
--- a/altair/schema/baseobject.py
+++ b/altair/schema/baseobject.py
@@ -74,8 +74,7 @@ from IPython.core.getipython import get_ipython
 class TraitletIPCompleter(IPCompleter):
     def _default_arguments(self, obj):
         args = super(TraitletIPCompleter, self)._default_arguments(obj)
-        args.append('asdf')
-        if isinstance(obj, type) and issubclass(obj, T.HasTraits):
+        if isinstance(obj, type) and issubclass(obj, BaseObject):
             args.extend(obj.class_trait_names())
         return list(set(args))
 

--- a/altair/schema/baseobject.py
+++ b/altair/schema/baseobject.py
@@ -80,6 +80,7 @@ class TraitletIPCompleter(IPCompleter):
 
 def enable_traitlet_completer():
     ip = get_ipython()
-    ip.Completer.__class__ = TraitletIPCompleter
+    if ip is not None:
+        ip.Completer.__class__ = TraitletIPCompleter
 
 enable_traitlet_completer()

--- a/altair/schema/baseobject.py
+++ b/altair/schema/baseobject.py
@@ -63,3 +63,24 @@ def trait_to_dict(obj):
         return [trait_to_dict(o) for o in obj]
     else:
         return obj
+
+
+#############################################################################
+# Hack to make traitlet arguments tab-complete in IPython
+
+from IPython.core.completer import IPCompleter
+from IPython.core.getipython import get_ipython
+
+class TraitletIPCompleter(IPCompleter):
+    def _default_arguments(self, obj):
+        args = super(TraitletIPCompleter, self)._default_arguments(obj)
+        args.append('asdf')
+        if isinstance(obj, type) and issubclass(obj, T.HasTraits):
+            args.extend(obj.class_trait_names())
+        return list(set(args))
+
+def enable_traitlet_completer():
+    ip = get_ipython()
+    ip.Completer.__class__ = TraitletIPCompleter
+
+enable_traitlet_completer()


### PR DESCRIPTION
This is a hack that enables tab completion for traits of any ``HasTraits`` class. Operationally, this means that, for example, if you type
```
In [1]: from altair import *
In [2]: Layer(des<TAB>
```
it will be auto-completed to
```
In [2]: Layer(description=
```
because ``Layer`` has a ``description`` trait.

I wasn't able to figure out how to do this through the normal completer hooks, so I used a hack that works but will likely be very brittle. I don't think this solution should be merged, but I'd love some feedback on what a better solution might be.