### PR TITLE
ENH: add to_html() methods

### DIFF
--- a/altair/api.py
+++ b/altair/api.py
@@ -79,7 +79,7 @@ class TopLevelMixin(object):
             The HTML template to use. This should have a format method, which
             accepts a "spec" and "title" argument. Note that a standard Python
             format string meets these requirements.
-            By default, uses DEFAULT_TEMPLATE.
+            By default, uses altair.utils.html.DEFAULT_TEMPLATE.
         title : string
             The title to use in the document. Default is "Vega-Lite Chart"
         kwargs :

--- a/altair/api.py
+++ b/altair/api.py
@@ -70,6 +70,29 @@ def load_vegalite_spec(spec):
 # Top-level Objects
 #*************************************************************************
 class TopLevelMixin(object):
+    def to_html(self, template=None, title=None, **kwargs):
+        """Emit a stand-alone HTML document containing this chart.
+
+        Parameters
+        ----------
+        template : string
+            The HTML template to use. This should have a format method, which
+            accepts a "spec" and "title" argument. Note that a standard Python
+            format string meets these requirements.
+            By default, uses DEFAULT_TEMPLATE.
+        title : string
+            The title to use in the document. Default is "Vega-Lite Chart"
+        kwargs :
+            additional keywords to be passed to the template
+
+        Returns
+        -------
+        html : string
+            A string of HTML representing the chart
+        """
+        from .utils.html import to_html
+        return to_html(self.to_dict(), template=template, title=title)
+
     def _to_code(self, data=None):
         """Emit the CodeGen object used to export this chart to Python code."""
         return visitors.ToCode().visit(self, data)

--- a/altair/tests/test_api.py
+++ b/altair/tests/test_api.py
@@ -20,6 +20,16 @@ def test_chart_url_input():
 
     assert chart1.to_altair() == chart2.to_altair()
 
+def test_chart_to_html():
+    chart = Chart().encode(x='blah:Q')
+    html = chart.to_html(title='My Chart')
+    assert "<title>My Chart</title>" in html
+
+    html = chart.to_html(template="{title}<@>{spec}")
+    title, spec = html.split('<@>')
+    assert json.loads(spec) == chart.to_dict()
+    assert title == "Vega-Lite Chart"
+
 
 def test_encode_update():
     # Test that encode updates rather than overwrites

--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -1,0 +1,70 @@
+import json
+
+
+def to_html(json_dict, template=None, title=None, **kwargs):
+    """Embed a Vega-Lite JSON into an HTML document
+
+    Parameters
+    ----------
+    json_dict : dict
+        A dictionary describing the Vega-Lite specification.
+    template : string
+        The HTML template to use. This should have a format method, which
+        accepts a "spec" and "title" argument. Note that a standard Python
+        format string meets these requirements.
+        By default, uses DEFAULT_TEMPLATE.
+    title: string
+        The title to use in the document. Default is "Vega-Lite Chart"
+
+    Returns
+    -------
+    html : string
+        A string of HTML representing the chart
+    """
+    if template is None:
+        template = DEFAULT_TEMPLATE
+    if title is None:
+        title = "Vega-Lite Chart"
+    spec = json.dumps(json_dict, indent=4)
+    return template.format(spec=spec, title=title, **kwargs)
+
+
+DEFAULT_TEMPLATE = """
+<!DOCTYPE html>
+<head>
+  <title>{title}</title>
+  <meta charset="utf-8">
+
+  <script src="//d3js.org/d3.v3.min.js"></script>
+  <script src="//vega.github.io/vega/vega.js"></script>
+  <script src="//vega.github.io/vega-lite/vega-lite.js"></script>
+  <script src="//vega.github.io/vega-editor/vendor/vega-embed.js" charset="utf-8"></script>
+
+  <style media="screen">
+    /* Add space between vega-embed links  */
+    .vega-actions a {{
+      margin-right: 5px;
+    }}
+  </style>
+</head>
+<body>
+  <!-- Container for the visualization -->
+  <div id="vis"></div>
+
+  <script>
+  var vlSpec = {spec}
+
+  var embedSpec = {{
+    mode: "vega-lite",  // Instruct Vega-Embed to use the Vega-Lite compiler
+    spec: vlSpec
+  }};
+
+  // Embed the visualization in the container with id `vis`
+  vg.embed("#vis", embedSpec, function(error, result) {{
+    // Callback receiving the View instance and parsed Vega spec
+    // result.view is the View, which resides under the '#vis' element
+  }});
+  </script>
+</body>
+</html>
+"""

--- a/altair/utils/tests/test_html.py
+++ b/altair/utils/tests/test_html.py
@@ -1,0 +1,18 @@
+import json
+from ..html import to_html
+
+
+def test_to_html():
+    json_dict = dict(A=1, B={'C':2, 'D':3})
+    title = 'My Awesome Title'
+
+    # Smoke-test for the basic template
+    html = to_html(json_dict, title=title)
+    assert '<title>{0}</title>'.format(title) in html
+
+    # Test a custom template
+    custom_template = "{spec}<@>{title}"
+    html = to_html(json_dict, title=title, template=custom_template)
+    spec, embedded_title = html.split('<@>')
+    assert json.loads(spec) == json_dict
+    assert embedded_title == title


### PR DESCRIPTION
I started comparing our docs to those of Vega-Lite, and noticed that they emphasize how to publish visualizations online: https://vega.github.io/vega-lite/tutorials/getting_started.html#embed

This PR uses that example as a template, and creates a ``to_html()`` method for top-level objects which export charts to stand-alone HTML.