### PR TITLE
[MRG] Refactor shorthand parser

### DIFF
--- a/altair/api.py
+++ b/altair/api.py
@@ -299,8 +299,6 @@ class Chart(schema.ExtendedUnitSpec, TopLevelMixin):
         # data comes from wrappers, but self.data overrides this if defined
         if self.data is not None:
             kwargs['data'] = self.data
-        if self.transform and self.transform.calculate:
-            kwargs['calculated_fields'] = [f.field for f in self.transform.calculate]
         super(Chart, self)._finalize(**kwargs)
 
 
@@ -353,8 +351,6 @@ class LayeredChart(schema.LayerSpec, TopLevelMixin):
         # data comes from wrappers, but self.data overrides this if defined
         if self.data is not None:
             kwargs['data'] = self.data
-        if self.transform and self.transform.calculate:
-            kwargs['calculated_fields'] = [f.field for f in self.transform.calculate]
         super(LayeredChart, self)._finalize(**kwargs)
 
 
@@ -409,6 +405,4 @@ class FacetedChart(schema.FacetSpec, TopLevelMixin):
         # data comes from wrappers, but self.data overrides this if defined
         if self.data is not None:
             kwargs['data'] = self.data
-        if self.transform and self.transform.calculate:
-            kwargs['calculated_fields'] = [f.field for f in self.transform.calculate]
         super(FacetedChart, self)._finalize(**kwargs)

--- a/altair/api.py
+++ b/altair/api.py
@@ -299,6 +299,8 @@ class Chart(schema.ExtendedUnitSpec, TopLevelMixin):
         # data comes from wrappers, but self.data overrides this if defined
         if self.data is not None:
             kwargs['data'] = self.data
+        if self.transform and self.transform.calculate:
+            kwargs['calculated_fields'] = [f.field for f in self.transform.calculate]
         super(Chart, self)._finalize(**kwargs)
 
 
@@ -351,6 +353,8 @@ class LayeredChart(schema.LayerSpec, TopLevelMixin):
         # data comes from wrappers, but self.data overrides this if defined
         if self.data is not None:
             kwargs['data'] = self.data
+        if self.transform and self.transform.calculate:
+            kwargs['calculated_fields'] = [f.field for f in self.transform.calculate]
         super(LayeredChart, self)._finalize(**kwargs)
 
 
@@ -405,4 +409,6 @@ class FacetedChart(schema.FacetSpec, TopLevelMixin):
         # data comes from wrappers, but self.data overrides this if defined
         if self.data is not None:
             kwargs['data'] = self.data
+        if self.transform and self.transform.calculate:
+            kwargs['calculated_fields'] = [f.field for f in self.transform.calculate]
         super(FacetedChart, self)._finalize(**kwargs)

--- a/altair/schema/_wrappers/channel_wrappers.py
+++ b/altair/schema/_wrappers/channel_wrappers.py
@@ -53,16 +53,9 @@ class PositionChannel(PositionChannelDef):
         """Finalize object: this involves inferring types if necessary"""
         data = kwargs.get('data', None)
 
-        # parse the shorthand, including validation of fields if available
-        if self.shorthand:
-            if isinstance(data, pd.DataFrame):
-                valid_fields = (list(data.columns)
-                                + kwargs.get('calculated_fields', []))
-            else:
-                valid_fields = None
-            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
-            for key, val in dct.items():
-                setattr(self, key, val)
+        # parse the shorthand to extract the field, type, and aggregate
+        for key, val in parse_shorthand(self.shorthand).items():
+            setattr(self, key, val)
 
         # infer the type if not already specified
         if not self.type:
@@ -113,16 +106,9 @@ class ChannelWithLegend(ChannelDefWithLegend):
         """Finalize object: this involves inferring types if necessary"""
         data = kwargs.get('data', None)
 
-        # parse the shorthand, including validation of fields if available
-        if self.shorthand:
-            if isinstance(data, pd.DataFrame):
-                valid_fields = (list(data.columns)
-                                + kwargs.get('calculated_fields', []))
-            else:
-                valid_fields = None
-            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
-            for key, val in dct.items():
-                setattr(self, key, val)
+        # parse the shorthand to extract the field, type, and aggregate
+        for key, val in parse_shorthand(self.shorthand).items():
+            setattr(self, key, val)
 
         # infer the type if not already specified
         if not self.type:
@@ -167,16 +153,9 @@ class Field(FieldDef):
         """Finalize object: this involves inferring types if necessary"""
         data = kwargs.get('data', None)
 
-        # parse the shorthand, including validation of fields if available
-        if self.shorthand:
-            if isinstance(data, pd.DataFrame):
-                valid_fields = (list(data.columns)
-                                + kwargs.get('calculated_fields', []))
-            else:
-                valid_fields = None
-            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
-            for key, val in dct.items():
-                setattr(self, key, val)
+        # parse the shorthand to extract the field, type, and aggregate
+        for key, val in parse_shorthand(self.shorthand).items():
+            setattr(self, key, val)
 
         # infer the type if not already specified
         if not self.type:
@@ -223,16 +202,9 @@ class OrderChannel(OrderChannelDef):
         """Finalize object: this involves inferring types if necessary"""
         data = kwargs.get('data', None)
 
-        # parse the shorthand, including validation of fields if available
-        if self.shorthand:
-            if isinstance(data, pd.DataFrame):
-                valid_fields = (list(data.columns)
-                                + kwargs.get('calculated_fields', []))
-            else:
-                valid_fields = None
-            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
-            for key, val in dct.items():
-                setattr(self, key, val)
+        # parse the shorthand to extract the field, type, and aggregate
+        for key, val in parse_shorthand(self.shorthand).items():
+            setattr(self, key, val)
 
         # infer the type if not already specified
         if not self.type:

--- a/altair/schema/_wrappers/channel_wrappers.py
+++ b/altair/schema/_wrappers/channel_wrappers.py
@@ -62,6 +62,8 @@ class PositionChannel(PositionChannelDef):
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
+        super(PositionChannel, self)._finalize(**kwargs)
+
 
 class ChannelWithLegend(ChannelDefWithLegend):
     """Wrapper for Vega-Lite ChannelDefWithLegend definition.
@@ -115,6 +117,8 @@ class ChannelWithLegend(ChannelDefWithLegend):
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
+        super(ChannelWithLegend, self)._finalize(**kwargs)
+
 
 class Field(FieldDef):
     """Wrapper for Vega-Lite FieldDef definition.
@@ -161,6 +165,8 @@ class Field(FieldDef):
         if not self.type:
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
+
+        super(Field, self)._finalize(**kwargs)
 
 
 class OrderChannel(OrderChannelDef):
@@ -210,5 +216,7 @@ class OrderChannel(OrderChannelDef):
         if not self.type:
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
+
+        super(OrderChannel, self)._finalize(**kwargs)
 
 

--- a/altair/schema/_wrappers/channel_wrappers.py
+++ b/altair/schema/_wrappers/channel_wrappers.py
@@ -50,14 +50,13 @@ class PositionChannel(PositionChannelDef):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        data = kwargs.get('data', None)
-
         # parse the shorthand to extract the field, type, and aggregate
         for key, val in parse_shorthand(self.shorthand).items():
             setattr(self, key, val)
 
         # infer the type if not already specified
-        if not self.type:
+        if self.type is None:
+            data = kwargs.get('data', None)
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
@@ -105,14 +104,13 @@ class ChannelWithLegend(ChannelDefWithLegend):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        data = kwargs.get('data', None)
-
         # parse the shorthand to extract the field, type, and aggregate
         for key, val in parse_shorthand(self.shorthand).items():
             setattr(self, key, val)
 
         # infer the type if not already specified
-        if not self.type:
+        if self.type is None:
+            data = kwargs.get('data', None)
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
@@ -154,14 +152,13 @@ class Field(FieldDef):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        data = kwargs.get('data', None)
-
         # parse the shorthand to extract the field, type, and aggregate
         for key, val in parse_shorthand(self.shorthand).items():
             setattr(self, key, val)
 
         # infer the type if not already specified
-        if not self.type:
+        if self.type is None:
+            data = kwargs.get('data', None)
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
@@ -205,14 +202,13 @@ class OrderChannel(OrderChannelDef):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        data = kwargs.get('data', None)
-
         # parse the shorthand to extract the field, type, and aggregate
         for key, val in parse_shorthand(self.shorthand).items():
             setattr(self, key, val)
 
         # infer the type if not already specified
-        if not self.type:
+        if self.type is None:
+            data = kwargs.get('data', None)
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 

--- a/altair/schema/_wrappers/channel_wrappers.py
+++ b/altair/schema/_wrappers/channel_wrappers.py
@@ -5,7 +5,6 @@ import traitlets as T
 import pandas as pd
 
 from ...utils import parse_shorthand, infer_vegalite_type
-from ...utils import INV_TYPECODE_MAP, TYPE_ABBR
 
 from .._interface import Type
 from .._interface import ChannelDefWithLegend, FieldDef, OrderChannelDef, PositionChannelDef
@@ -41,25 +40,6 @@ class PositionChannel(PositionChannelDef):
     """
     # Traitlets
     shorthand = T.Unicode('')
-
-    # add type abbreviations to the valid values &
-    # use an observer below to expand abbreviations if they come up
-    type = T.Union([Type(), T.Enum(['Q', 'N', 'O', 'T'])],
-                   allow_none=True, default_value=None)
-
-    @T.observe('shorthand')
-    def _shorthand_changed(self, change):
-        D = parse_shorthand(change['new'])
-        for key, val in D.items():
-            setattr(self, key, val)
-
-    @T.observe('type')
-    def _type_changed(self, change):
-        new = change['new']
-        if new in TYPE_ABBR:
-            self.type = INV_TYPECODE_MAP[new]
-
-    # Class Attributes
     skip = ['shorthand']
 
     # Class Methods
@@ -71,8 +51,21 @@ class PositionChannel(PositionChannelDef):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        if self.type is None:
-            data = kwargs.get('data', None)
+        data = kwargs.get('data', None)
+
+        # parse the shorthand, including validation of fields if available
+        if self.shorthand:
+            if isinstance(data, pd.DataFrame):
+                valid_fields = (list(data.columns)
+                                + kwargs.get('calculated_fields', []))
+            else:
+                valid_fields = None
+            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
+            for key, val in dct.items():
+                setattr(self, key, val)
+
+        # infer the type if not already specified
+        if not self.type:
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
@@ -107,25 +100,6 @@ class ChannelWithLegend(ChannelDefWithLegend):
     """
     # Traitlets
     shorthand = T.Unicode('')
-
-    # add type abbreviations to the valid values &
-    # use an observer below to expand abbreviations if they come up
-    type = T.Union([Type(), T.Enum(['Q', 'N', 'O', 'T'])],
-                   allow_none=True, default_value=None)
-
-    @T.observe('shorthand')
-    def _shorthand_changed(self, change):
-        D = parse_shorthand(change['new'])
-        for key, val in D.items():
-            setattr(self, key, val)
-
-    @T.observe('type')
-    def _type_changed(self, change):
-        new = change['new']
-        if new in TYPE_ABBR:
-            self.type = INV_TYPECODE_MAP[new]
-
-    # Class Attributes
     skip = ['shorthand']
 
     # Class Methods
@@ -137,8 +111,21 @@ class ChannelWithLegend(ChannelDefWithLegend):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        if self.type is None:
-            data = kwargs.get('data', None)
+        data = kwargs.get('data', None)
+
+        # parse the shorthand, including validation of fields if available
+        if self.shorthand:
+            if isinstance(data, pd.DataFrame):
+                valid_fields = (list(data.columns)
+                                + kwargs.get('calculated_fields', []))
+            else:
+                valid_fields = None
+            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
+            for key, val in dct.items():
+                setattr(self, key, val)
+
+        # infer the type if not already specified
+        if not self.type:
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
@@ -167,25 +154,6 @@ class Field(FieldDef):
     """
     # Traitlets
     shorthand = T.Unicode('')
-
-    # add type abbreviations to the valid values &
-    # use an observer below to expand abbreviations if they come up
-    type = T.Union([Type(), T.Enum(['Q', 'N', 'O', 'T'])],
-                   allow_none=True, default_value=None)
-
-    @T.observe('shorthand')
-    def _shorthand_changed(self, change):
-        D = parse_shorthand(change['new'])
-        for key, val in D.items():
-            setattr(self, key, val)
-
-    @T.observe('type')
-    def _type_changed(self, change):
-        new = change['new']
-        if new in TYPE_ABBR:
-            self.type = INV_TYPECODE_MAP[new]
-
-    # Class Attributes
     skip = ['shorthand']
 
     # Class Methods
@@ -197,8 +165,21 @@ class Field(FieldDef):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        if self.type is None:
-            data = kwargs.get('data', None)
+        data = kwargs.get('data', None)
+
+        # parse the shorthand, including validation of fields if available
+        if self.shorthand:
+            if isinstance(data, pd.DataFrame):
+                valid_fields = (list(data.columns)
+                                + kwargs.get('calculated_fields', []))
+            else:
+                valid_fields = None
+            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
+            for key, val in dct.items():
+                setattr(self, key, val)
+
+        # infer the type if not already specified
+        if not self.type:
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
@@ -229,25 +210,6 @@ class OrderChannel(OrderChannelDef):
     """
     # Traitlets
     shorthand = T.Unicode('')
-
-    # add type abbreviations to the valid values &
-    # use an observer below to expand abbreviations if they come up
-    type = T.Union([Type(), T.Enum(['Q', 'N', 'O', 'T'])],
-                   allow_none=True, default_value=None)
-
-    @T.observe('shorthand')
-    def _shorthand_changed(self, change):
-        D = parse_shorthand(change['new'])
-        for key, val in D.items():
-            setattr(self, key, val)
-
-    @T.observe('type')
-    def _type_changed(self, change):
-        new = change['new']
-        if new in TYPE_ABBR:
-            self.type = INV_TYPECODE_MAP[new]
-
-    # Class Attributes
     skip = ['shorthand']
 
     # Class Methods
@@ -259,8 +221,21 @@ class OrderChannel(OrderChannelDef):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        if self.type is None:
-            data = kwargs.get('data', None)
+        data = kwargs.get('data', None)
+
+        # parse the shorthand, including validation of fields if available
+        if self.shorthand:
+            if isinstance(data, pd.DataFrame):
+                valid_fields = (list(data.columns)
+                                + kwargs.get('calculated_fields', []))
+            else:
+                valid_fields = None
+            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
+            for key, val in dct.items():
+                setattr(self, key, val)
+
+        # infer the type if not already specified
+        if not self.type:
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 

--- a/altair/schema/_wrappers/channel_wrappers.py
+++ b/altair/schema/_wrappers/channel_wrappers.py
@@ -6,7 +6,6 @@ import pandas as pd
 
 from ...utils import parse_shorthand, infer_vegalite_type
 
-from .._interface import Type
 from .._interface import ChannelDefWithLegend, FieldDef, OrderChannelDef, PositionChannelDef
 
 

--- a/altair/tests/test_api.py
+++ b/altair/tests/test_api.py
@@ -321,8 +321,9 @@ def test_finalize(sample_code):
     assert obj.to_altair(data='cars') == sample_code
 
     # Confirm that _finalize() changes the state
+    assert obj.encoding.x.type is None
     obj._finalize()
-    assert obj.to_altair(data='cars') != sample_code
+    assert obj.encoding.x.type is not None
 
     # Confirm that finalized object contains correct type information
     D = obj.to_dict(data=False)

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -13,7 +13,7 @@ TYPECODE_MAP = {'ordinal': 'O',
                 'quantitative': 'Q',
                 'temporal': 'T'}
 
-INV_TYPECODE_MAP = {v:k for k,v in TYPECODE_MAP.items()}
+INV_TYPECODE_MAP = {v: k for k, v in TYPECODE_MAP.items()}
 
 TYPE_ABBR = TYPECODE_MAP.values()
 
@@ -44,6 +44,7 @@ def parse_shorthand(shorthand, valid_fields=None):
     if not shorthand:
         return {}
 
+    # Must import this here to avoid circular imports
     from ..schema import AggregateOp
     valid_aggregates = AggregateOp().values
     valid_typecodes = list(TYPECODE_MAP) + list(INV_TYPECODE_MAP)
@@ -59,6 +60,7 @@ def parse_shorthand(shorthand, valid_fields=None):
     regexps = [re.compile('\A' + p.format(**units) + '\Z', re.DOTALL)
                for p in patterns]
 
+    # find matches depending on valid fields passed
     matches = [exp.match(shorthand).groupdict() for exp in regexps
                if exp.match(shorthand)]
     if valid_fields is None:
@@ -70,7 +72,7 @@ def parse_shorthand(shorthand, valid_fields=None):
             if match['field'] in valid_fields:
                 match_to_return = match
                 break
-        else: # nobreak
+        else:  # nobreak
             raise ValueError('No matching field for shorthand: '
                              '{0}'.format(matches[0]))
 
@@ -82,6 +84,9 @@ def parse_shorthand(shorthand, valid_fields=None):
 
 
 def construct_shorthand(field=None, aggregate=None, type=None):
+    """Construct a shorthand representation.
+
+    See also: parse_shorthand"""
     if field is None:
         return ''
 
@@ -99,7 +104,7 @@ def construct_shorthand(field=None, aggregate=None, type=None):
     return sh
 
 
-def infer_vegalite_type(data, name=None):
+def infer_vegalite_type(data, field=None):
     """
     From an array-like input, infer the correct vega typecode
     ('O', 'N', 'Q', or 'T')
@@ -109,8 +114,8 @@ def infer_vegalite_type(data, name=None):
     data: Numpy array or Pandas Series
     field: str column name
     """
-    # See if we can read the type from the name
-    if name is not None:
+    # See if we can read the type from the field
+    if field is not None:
         parsed = parse_shorthand(field)
         if parsed.get('type'):
             return parsed['type']

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -79,7 +79,7 @@ def parse_shorthand(shorthand, valid_fields=None):
     # Use short form of the type expression
     typ = match_to_return.get('type', None)
     if typ:
-        match_to_return['type'] = TYPECODE_MAP.get(typ, typ)
+        match_to_return['type'] = INV_TYPECODE_MAP.get(typ, typ)
     return match_to_return
 
 
@@ -107,7 +107,7 @@ def construct_shorthand(field=None, aggregate=None, type=None):
 def infer_vegalite_type(data, field=None):
     """
     From an array-like input, infer the correct vega typecode
-    ('O', 'N', 'Q', or 'T')
+    ('ordinal', 'nominal', 'quantitative', or 'temporal')
 
     Parameters
     ----------
@@ -127,18 +127,16 @@ def infer_vegalite_type(data, field=None):
 
     if typ in ['floating', 'mixed-integer-float', 'integer',
                'mixed-integer', 'complex']:
-        typecode = 'quantitative'
+        return 'quantitative'
     elif typ in ['string', 'bytes', 'categorical', 'boolean', 'mixed', 'unicode']:
-        typecode = 'nominal'
+        return 'nominal'
     elif typ in ['datetime', 'datetime64', 'timedelta',
                  'timedelta64', 'date', 'time', 'period']:
-        typecode = 'temporal'
+        return 'temporal'
     else:
         warnings.warn("I don't know how to infer vegalite type from '{0}'.  "
                       "Defaulting to nominal.".format(typ))
-        typecode = 'nominal'
-
-    return TYPECODE_MAP[typecode]
+        return 'nominal'
 
 
 def sanitize_dataframe(df):

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -13,12 +13,35 @@ def test_parse_shorthand():
         assert parse_shorthand(s) == kwargs
 
     check('')
+
+    # Fields alone
     check('foobar', field='foobar')
+    check('blah:(fd ', field='blah:(fd ')
+
+    # Fields with type
+    check('foobar:quantitative', type='Q', field='foobar')
     check('foobar:nominal', type='N', field='foobar')
+    check('foobar:ordinal', type='O', field='foobar')
+    check('foobar:temporal', type='T', field='foobar')
+
+    check('foobar:Q', type='Q', field='foobar')
+    check('foobar:N', type='N', field='foobar')
     check('foobar:O', type='O', field='foobar')
-    check('avg(foobar)', field='foobar', aggregate='avg')
+    check('foobar:T', type='T', field='foobar')
+
+    # Fields with aggregate and/or type
+    check('average(foobar)', field='foobar', aggregate='average')
     check('min(foobar):temporal', type='T', field='foobar', aggregate='min')
     check('sum(foobar):Q', type='Q', field='foobar', aggregate='sum')
+
+    # check that invalid arguments are not split-out
+    check('invalid(blah)', field='invalid(blah)')
+    check('blah:invalid', field='blah:invalid')
+    check('invalid(blah):invalid', field='invalid(blah):invalid')
+
+    # check parsing in presence of strange characters
+    check('average(a b:(c\nd):Q', aggregate='average',
+          field='a b:(c\nd', type='Q')
 
 
 def test_infer_vegalite_type():

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -5,7 +5,8 @@ import json
 import numpy as np
 import pandas as pd
 
-from .. import parse_shorthand, infer_vegalite_type, sanitize_dataframe
+from .. import (parse_shorthand, construct_shorthand,
+                infer_vegalite_type, sanitize_dataframe)
 
 
 def test_parse_shorthand():
@@ -70,6 +71,16 @@ def test_parse_shorthand_invalid_fields():
     check_raises('average(foo):Q', ['bar', 'baz'])
 
 
+def test_shorthand_roundtrip():
+    def check(**kwargs):
+        assert parse_shorthand(construct_shorthand(**kwargs)) == kwargs
+
+    check(field='foo')
+    check(field='foo', aggregate='average')
+    check(field='foo', type='Q')
+    check(field='foo', aggregate='average', type='Q')
+
+
 def test_infer_vegalite_type():
     def _check(arr, typ):
         assert infer_vegalite_type(arr) == typ
@@ -85,7 +96,7 @@ def test_infer_vegalite_type():
     _check(nulled, 'Q')
     _check(['a', 'b', 'c'], 'N')
 
-    if hasattr(pytest, 'warns'): # added in pytest 2.8
+    if hasattr(pytest, 'warns'):  # added in pytest 2.8
         with pytest.warns(UserWarning):
             _check([], 'N')
     else:

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -44,6 +44,32 @@ def test_parse_shorthand():
           field='a b:(c\nd', type='Q')
 
 
+def test_parse_shorthand_valid_fields():
+    def check(shorthand, valid_fields, **kwargs):
+        assert parse_shorthand(shorthand, valid_fields) == kwargs
+
+    check('foo', ['foo', 'bar'], field='foo')
+    check('average(foo)', ['average(foo)'], field='average(foo)')
+    check('average(foo)', ['foo', 'average(foo)'], field='average(foo)')
+    check('average(foo):Q', ['foo', 'average(foo)'],
+          field='average(foo)', type='Q')
+    check('average(foo):Q', ['foo', 'average(foo)', 'average(foo):Q'],
+          field='average(foo):Q')
+    check('average(average(foo):Q):Q', ['average(foo):Q'],
+          field='average(foo):Q', aggregate='average', type='Q')
+
+
+def test_parse_shorthand_invalid_fields():
+    def check_raises(shorthand, valid_fields):
+        with pytest.raises(ValueError) as err:
+            parse_shorthand(shorthand, valid_fields)
+        assert str(err.value).startswith('No matching field for shorthand:')
+
+    check_raises('foo', ['bar', 'baz'])
+    check_raises('average(foo)', ['bar', 'baz'])
+    check_raises('average(foo):Q', ['bar', 'baz'])
+
+
 def test_infer_vegalite_type():
     def _check(arr, typ):
         assert infer_vegalite_type(arr) == typ

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -20,20 +20,20 @@ def test_parse_shorthand():
     check('blah:(fd ', field='blah:(fd ')
 
     # Fields with type
-    check('foobar:quantitative', type='Q', field='foobar')
-    check('foobar:nominal', type='N', field='foobar')
-    check('foobar:ordinal', type='O', field='foobar')
-    check('foobar:temporal', type='T', field='foobar')
+    check('foobar:quantitative', type='quantitative', field='foobar')
+    check('foobar:nominal', type='nominal', field='foobar')
+    check('foobar:ordinal', type='ordinal', field='foobar')
+    check('foobar:temporal', type='temporal', field='foobar')
 
-    check('foobar:Q', type='Q', field='foobar')
-    check('foobar:N', type='N', field='foobar')
-    check('foobar:O', type='O', field='foobar')
-    check('foobar:T', type='T', field='foobar')
+    check('foobar:Q', type='quantitative', field='foobar')
+    check('foobar:N', type='nominal', field='foobar')
+    check('foobar:O', type='ordinal', field='foobar')
+    check('foobar:T', type='temporal', field='foobar')
 
     # Fields with aggregate and/or type
     check('average(foobar)', field='foobar', aggregate='average')
-    check('min(foobar):temporal', type='T', field='foobar', aggregate='min')
-    check('sum(foobar):Q', type='Q', field='foobar', aggregate='sum')
+    check('min(foobar):temporal', type='temporal', field='foobar', aggregate='min')
+    check('sum(foobar):Q', type='quantitative', field='foobar', aggregate='sum')
 
     # check that invalid arguments are not split-out
     check('invalid(blah)', field='invalid(blah)')
@@ -42,7 +42,7 @@ def test_parse_shorthand():
 
     # check parsing in presence of strange characters
     check('average(a b:(c\nd):Q', aggregate='average',
-          field='a b:(c\nd', type='Q')
+          field='a b:(c\nd', type='quantitative')
 
 
 def test_parse_shorthand_valid_fields():
@@ -53,11 +53,11 @@ def test_parse_shorthand_valid_fields():
     check('average(foo)', ['average(foo)'], field='average(foo)')
     check('average(foo)', ['foo', 'average(foo)'], field='average(foo)')
     check('average(foo):Q', ['foo', 'average(foo)'],
-          field='average(foo)', type='Q')
+          field='average(foo)', type='quantitative')
     check('average(foo):Q', ['foo', 'average(foo)', 'average(foo):Q'],
           field='average(foo):Q')
     check('average(average(foo):Q):Q', ['average(foo):Q'],
-          field='average(foo):Q', aggregate='average', type='Q')
+          field='average(foo):Q', aggregate='average', type='quantitative')
 
 
 def test_parse_shorthand_invalid_fields():
@@ -77,32 +77,32 @@ def test_shorthand_roundtrip():
 
     check(field='foo')
     check(field='foo', aggregate='average')
-    check(field='foo', type='Q')
-    check(field='foo', aggregate='average', type='Q')
+    check(field='foo', type='quantitative')
+    check(field='foo', aggregate='average', type='quantitative')
 
 
 def test_infer_vegalite_type():
     def _check(arr, typ):
         assert infer_vegalite_type(arr) == typ
 
-    _check(np.arange(5, dtype=float), 'Q')
-    _check(np.arange(5, dtype=int), 'Q')
-    _check(np.zeros(5, dtype=bool), 'N')
-    _check(pd.date_range('2012', '2013'), 'T')
-    _check(pd.timedelta_range(365, periods=12), 'T')
+    _check(np.arange(5, dtype=float), 'quantitative')
+    _check(np.arange(5, dtype=int), 'quantitative')
+    _check(np.zeros(5, dtype=bool), 'nominal')
+    _check(pd.date_range('2012', '2013'), 'temporal')
+    _check(pd.timedelta_range(365, periods=12), 'temporal')
 
     nulled = pd.Series(np.random.randint(10, size=10))
     nulled[0] = None
-    _check(nulled, 'Q')
-    _check(['a', 'b', 'c'], 'N')
+    _check(nulled, 'quantitative')
+    _check(['a', 'b', 'c'], 'nominal')
 
     if hasattr(pytest, 'warns'):  # added in pytest 2.8
         with pytest.warns(UserWarning):
-            _check([], 'N')
+            _check([], 'nominal')
     else:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            _check([], 'N')
+            _check([], 'nominal')
 
 
 def test_sanitize_dataframe():

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -45,32 +45,6 @@ def test_parse_shorthand():
           field='a b:(c\nd', type='quantitative')
 
 
-def test_parse_shorthand_valid_fields():
-    def check(shorthand, valid_fields, **kwargs):
-        assert parse_shorthand(shorthand, valid_fields) == kwargs
-
-    check('foo', ['foo', 'bar'], field='foo')
-    check('average(foo)', ['average(foo)'], field='average(foo)')
-    check('average(foo)', ['foo', 'average(foo)'], field='average(foo)')
-    check('average(foo):Q', ['foo', 'average(foo)'],
-          field='average(foo)', type='quantitative')
-    check('average(foo):Q', ['foo', 'average(foo)', 'average(foo):Q'],
-          field='average(foo):Q')
-    check('average(average(foo):Q):Q', ['average(foo):Q'],
-          field='average(foo):Q', aggregate='average', type='quantitative')
-
-
-def test_parse_shorthand_invalid_fields():
-    def check_raises(shorthand, valid_fields):
-        with pytest.raises(ValueError) as err:
-            parse_shorthand(shorthand, valid_fields)
-        assert str(err.value).startswith('No matching field for shorthand:')
-
-    check_raises('foo', ['bar', 'baz'])
-    check_raises('average(foo)', ['bar', 'baz'])
-    check_raises('average(foo):Q', ['bar', 'baz'])
-
-
 def test_shorthand_roundtrip():
     def check(**kwargs):
         assert parse_shorthand(construct_shorthand(**kwargs)) == kwargs

--- a/altair/utils/visitors.py
+++ b/altair/utils/visitors.py
@@ -85,9 +85,12 @@ class ToCode(Visitor):
         return CodeGen(obj.__class__.__name__, kwargs=kwds)
 
     def _visit_ChannelWrapper(self, obj, *args, **kwargs):
-        shorthand = construct_shorthand(field=obj.field,
-                                        aggregate=obj.aggregate,
-                                        type=obj.type)
+        if obj.shorthand:
+            shorthand = obj.shorthand
+        else:
+            shorthand = construct_shorthand(field=obj.field,
+                                            aggregate=obj.aggregate,
+                                            type=obj.type)
         code = self.visit_BaseObject(obj)
         if shorthand:
             code.add_args(repr(shorthand))

--- a/tools/templates/channel_wrappers.tpl
+++ b/tools/templates/channel_wrappers.tpl
@@ -53,5 +53,7 @@ class {{ object.name }}({{ object.base.name }}):
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 
+        super({{ object.name }}, self)._finalize(**kwargs)
+
 
 {% endfor %}

--- a/tools/templates/channel_wrappers.tpl
+++ b/tools/templates/channel_wrappers.tpl
@@ -44,16 +44,9 @@ class {{ object.name }}({{ object.base.name }}):
         """Finalize object: this involves inferring types if necessary"""
         data = kwargs.get('data', None)
 
-        # parse the shorthand, including validation of fields if available
-        if self.shorthand:
-            if isinstance(data, pd.DataFrame):
-                valid_fields = (list(data.columns)
-                                + kwargs.get('calculated_fields', []))
-            else:
-                valid_fields = None
-            dct = parse_shorthand(self.shorthand, valid_fields=valid_fields)
-            for key, val in dct.items():
-                setattr(self, key, val)
+        # parse the shorthand to extract the field, type, and aggregate
+        for key, val in parse_shorthand(self.shorthand).items():
+            setattr(self, key, val)
 
         # infer the type if not already specified
         if not self.type:

--- a/tools/templates/channel_wrappers.tpl
+++ b/tools/templates/channel_wrappers.tpl
@@ -41,14 +41,13 @@ class {{ object.name }}({{ object.base.name }}):
 
     def _finalize(self, **kwargs):
         """Finalize object: this involves inferring types if necessary"""
-        data = kwargs.get('data', None)
-
         # parse the shorthand to extract the field, type, and aggregate
         for key, val in parse_shorthand(self.shorthand).items():
             setattr(self, key, val)
 
         # infer the type if not already specified
-        if not self.type:
+        if self.type is None:
+            data = kwargs.get('data', None)
             if isinstance(data, pd.DataFrame) and self.field in data:
                 self.type = infer_vegalite_type(data[self.field])
 

--- a/tools/templates/channel_wrappers.tpl
+++ b/tools/templates/channel_wrappers.tpl
@@ -6,7 +6,6 @@ import pandas as pd
 
 from ...utils import parse_shorthand, infer_vegalite_type
 
-from .._interface import Type
 {% for import_statement in objects|merge_imports -%}
   {{ import_statement }}
 {% endfor %}


### PR DESCRIPTION
Addresses #46 – parsing of shorthands is now more robust, so that column names with spaces, colons, parentheses, and other characters works.

Additionally, I moved the shorthand parsing to the ``_finalize()`` method, rather than using a traitlet observer. Due to the refactoring, I was also able to remove the specialization of ``type`` within channels, as well as observers of ``shorthand`` and ``type``.

The result is about 70 fewer lines of code overall, excluding the additional tests that are part of this PR.