### PR TITLE
missing a dependency for git in python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ traitlets
 ipython
 pandas
 vega>=0.4.1
+gitpython
+


### PR DESCRIPTION
was getting a `no module named git` error when I ran `make all`
