### PR TITLE
ENH: add Chart.serve() command to serve HTML

### DIFF
--- a/altair/api.py
+++ b/altair/api.py
@@ -191,6 +191,39 @@ class TopLevelMixin(object):
         from IPython.display import display
         display(self)
 
+    def serve(self, ip='127.0.0.1', port=8888, n_retries=50, files=None,
+              jupyter_warning=True, open_browser=True, http_server=None,
+              **html_kwargs):
+        """Open a web browser and visualize the chart
+
+        Parameters
+        ----------
+        html : string
+            HTML to serve
+        ip : string (default = '127.0.0.1')
+            ip address at which the HTML will be served.
+        port : int (default = 8888)
+            the port at which to serve the HTML
+        n_retries : int (default = 50)
+            the number of nearby ports to search if the specified port
+            is already in use.
+        files : dictionary (optional)
+            dictionary of extra content to serve
+        jupyter_warning : bool (optional)
+            if True (default), then print a warning if this is used
+            within the Jupyter notebook
+        open_browser : bool (optional)
+            if True (default), then open a web browser to the given HTML
+        http_server : class (optional)
+            optionally specify an HTTPServer class to use for showing the
+            figure. The default is Python's basic HTTPServer.
+        """
+        from .utils.server import serve
+        html = self.to_html(**html_kwargs)
+        serve(html, ip=ip, port=port, n_retries=n_retries,
+              files=files, jupyter_warning=jupyter_warning,
+              open_browser=open_browser, http_server=http_server)
+
 
 class Chart(schema.ExtendedUnitSpec, TopLevelMixin):
     _data = None

--- a/altair/tests/test_api.py
+++ b/altair/tests/test_api.py
@@ -361,3 +361,30 @@ def test_chart_to_json():
 
     import json
     assert chart.to_dict() == json.loads(chart.to_json())
+
+
+def test_chart_serve():
+    try:
+        # Python 2
+        from StringIO import StringIO as IO
+    except:
+        # Python 3
+        from io import BytesIO as IO
+    class MockRequest(object):
+        def makefile(self, *args, **kwargs):
+            return IO(b"GET /")
+
+    class MockServer(object):
+        def __init__(self, ip_port, Handler):
+            handler = Handler(MockRequest(), ip_port[0], self)
+
+        def serve_forever(self):
+            pass
+
+        def server_close(self):
+            pass
+
+    data = pd.DataFrame({'x':np.random.rand(10), 'y':np.random.rand(10)})
+    chart = Chart(data).mark_line().encode(x='x', y='y')
+
+    chart.serve(open_browser=False, http_server=MockServer)

--- a/altair/tests/test_api.py
+++ b/altair/tests/test_api.py
@@ -364,25 +364,7 @@ def test_chart_to_json():
 
 
 def test_chart_serve():
-    try:
-        # Python 2
-        from StringIO import StringIO as IO
-    except:
-        # Python 3
-        from io import BytesIO as IO
-    class MockRequest(object):
-        def makefile(self, *args, **kwargs):
-            return IO(b"GET /")
-
-    class MockServer(object):
-        def __init__(self, ip_port, Handler):
-            handler = Handler(MockRequest(), ip_port[0], self)
-
-        def serve_forever(self):
-            pass
-
-        def server_close(self):
-            pass
+    from altair.utils.server import MockServer
 
     data = pd.DataFrame({'x':np.random.rand(10), 'y':np.random.rand(10)})
     chart = Chart(data).mark_line().encode(x='x', y='y')

--- a/altair/utils/_py3k_compat.py
+++ b/altair/utils/_py3k_compat.py
@@ -6,6 +6,10 @@ PY3 = not PY2
 if PY2:
     string_types = basestring,
     integer_types = (int, long)
+    import BaseHTTPServer as server
+    from StringIO import StringIO as IO
 else:
     string_types = str,
     integer_types = int,
+    from http import server
+    from io import BytesIO as IO

--- a/altair/utils/server.py
+++ b/altair/utils/server.py
@@ -36,11 +36,7 @@ def generate_handler(html, files=None):
                 self.send_response(200)
                 self.send_header("Content-type", "text/html")
                 self.end_headers()
-                self.wfile.write("<html><head>"
-                                 "<title>mpld3 plot</title>"
-                                 "</head><body>\n".encode())
                 self.wfile.write(html.encode())
-                self.wfile.write("</body></html>".encode())
             elif self.path in files:
                 content_type, content = files[self.path]
                 self.send_response(200)

--- a/altair/utils/server.py
+++ b/altair/utils/server.py
@@ -10,6 +10,7 @@ import webbrowser
 import socket
 import itertools
 import random
+from ._py3k_compat import server, IO
 
 JUPYTER_WARNING = """
 Note: if you're in the Jupyter notebook, Chart.serve() is not the best
@@ -17,12 +18,23 @@ Note: if you're in the Jupyter notebook, Chart.serve() is not the best
 You must interrupt the kernel to cancel this command.
 """
 
-try:
-    # Python 2.x
-    import BaseHTTPServer as server
-except ImportError:
-    # Python 3.x
-    from http import server
+
+
+# Mock server used for testing
+
+class MockRequest(object):
+    def makefile(self, *args, **kwargs):
+        return IO(b"GET /")
+
+class MockServer(object):
+    def __init__(self, ip_port, Handler):
+        handler = Handler(MockRequest(), ip_port[0], self)
+
+    def serve_forever(self):
+        pass
+
+    def server_close(self):
+        pass
 
 
 def generate_handler(html, files=None):

--- a/altair/utils/server.py
+++ b/altair/utils/server.py
@@ -1,0 +1,124 @@
+"""
+A Simple server used to show altair graphics from a prompt or script.
+
+This is adapted from the mpld3 package; see
+https://github.com/mpld3/mpld3/blob/master/mpld3/_server.py
+"""
+import sys
+import threading
+import webbrowser
+import socket
+import itertools
+import random
+
+JUPYTER_WARNING = """
+Note: if you're in the Jupyter notebook, Chart.serve() is not the best
+      way to view plots. Consider using Chart.display().
+You must interrupt the kernel to cancel this command.
+"""
+
+try:
+    # Python 2.x
+    import BaseHTTPServer as server
+except ImportError:
+    # Python 3.x
+    from http import server
+
+
+def generate_handler(html, files=None):
+    if files is None:
+        files = {}
+
+    class MyHandler(server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            """Respond to a GET request."""
+            if self.path == '/':
+                self.send_response(200)
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+                self.wfile.write("<html><head>"
+                                 "<title>mpld3 plot</title>"
+                                 "</head><body>\n".encode())
+                self.wfile.write(html.encode())
+                self.wfile.write("</body></html>".encode())
+            elif self.path in files:
+                content_type, content = files[self.path]
+                self.send_response(200)
+                self.send_header("Content-type", content_type)
+                self.end_headers()
+                self.wfile.write(content.encode())
+            else:
+                self.send_error(404)
+
+    return MyHandler
+
+
+def find_open_port(ip, port, n=50):
+    """Find an open port near the specified port"""
+    ports = itertools.chain((port + i for i in range(n)),
+                            (port + random.randint(-2 * n, 2 * n)))
+
+    for port in ports:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = s.connect_ex((ip, port))
+        s.close()
+        if result != 0:
+            return port
+    raise ValueError("no open ports found")
+
+
+def serve(html, ip='127.0.0.1', port=8888, n_retries=50, files=None,
+          jupyter_warning=True, open_browser=True, http_server=None):
+    """Start a server serving the given HTML, and (optionally) open a browser
+
+    Parameters
+    ----------
+    html : string
+        HTML to serve
+    ip : string (default = '127.0.0.1')
+        ip address at which the HTML will be served.
+    port : int (default = 8888)
+        the port at which to serve the HTML
+    n_retries : int (default = 50)
+        the number of nearby ports to search if the specified port is in use.
+    files : dictionary (optional)
+        dictionary of extra content to serve
+    jupyter_warning : bool (optional)
+        if True (default), then print a warning if this is used within Jupyter
+    open_browser : bool (optional)
+        if True (default), then open a web browser to the given HTML
+    http_server : class (optional)
+        optionally specify an HTTPServer class to use for showing the
+        figure. The default is Python's basic HTTPServer.
+    """
+    port = find_open_port(ip, port, n_retries)
+    Handler = generate_handler(html, files)
+
+    if http_server is None:
+        srvr = server.HTTPServer((ip, port), Handler)
+    else:
+        srvr = http_server((ip, port), Handler)
+
+    if jupyter_warning:
+        try:
+            __IPYTHON__
+        except:
+            pass
+        else:
+            print(JUPYTER_WARNING)
+
+    # Start the server
+    print("Serving to http://{0}:{1}/    [Ctrl-C to exit]".format(ip, port))
+    sys.stdout.flush()
+
+    if open_browser:
+        # Use a thread to open a web browser pointing to the server
+        b = lambda: webbrowser.open('http://{0}:{1}'.format(ip, port))
+        threading.Thread(target=b).start()
+
+    try:
+        srvr.serve_forever()
+    except (KeyboardInterrupt, SystemExit):
+        print("\nstopping Server...")
+
+    srvr.server_close()

--- a/altair/utils/tests/test_server.py
+++ b/altair/utils/tests/test_server.py
@@ -2,31 +2,9 @@
 Test http server
 """
 
-try:
-    # Python 2
-    from StringIO import StringIO as IO
-except:
-    # Python 3
-    from io import BytesIO as IO
-
-
-from altair.utils.server import serve
+from altair.utils.server import serve, MockServer
 
 
 def test_serve():
-    class MockRequest(object):
-        def makefile(self, *args, **kwargs):
-            return IO(b"GET /")
-
-    class MockServer(object):
-        def __init__(self, ip_port, Handler):
-            handler = Handler(MockRequest(), ip_port[0], self)
-
-        def serve_forever(self):
-            pass
-
-        def server_close(self):
-            pass
-
     html = '<html><title>Title</title><body><p>Content</p></body></html>'
     serve(html, open_browser=False, http_server=MockServer)

--- a/altair/utils/tests/test_server.py
+++ b/altair/utils/tests/test_server.py
@@ -1,0 +1,32 @@
+"""
+Test http server
+"""
+
+try:
+    # Python 2
+    from StringIO import StringIO as IO
+except:
+    # Python 3
+    from io import BytesIO as IO
+
+
+from altair.utils.server import serve
+
+
+def test_serve():
+    class MockRequest(object):
+        def makefile(self, *args, **kwargs):
+            return IO(b"GET /")
+
+    class MockServer(object):
+        def __init__(self, ip_port, Handler):
+            handler = Handler(MockRequest(), ip_port[0], self)
+
+        def serve_forever(self):
+            pass
+
+        def server_close(self):
+            pass
+
+    html = '<html><title>Title</title><body><p>Content</p></body></html>'
+    serve(html, open_browser=False, http_server=MockServer)


### PR DESCRIPTION
This PR adds a functionality to create altair plots from outside the Jupyter notebook; e.g.

```python
from altair import Chart, load_dataset

cars = load_dataset('cars')

chart = Chart(cars).mark_point().encode(
    x='Horsepower',
    y='Miles_per_Gallon',
    color='Origin',
)

chart.serve()
```

The final line will create a local web server, and by default launch a web browser window showing this visualization.