### PR TITLE
ENH: add interface to save chart to PNG/SVG

### DIFF
--- a/altair/utils/node.py
+++ b/altair/utils/node.py
@@ -5,31 +5,30 @@ from __future__ import print_function
 
 import os
 import tempfile
-import random
 
 
-__all__ = ['savechart']
+__all__ = ['savechart', 'savechart_available']
 
-NODE_BIN_DIR = os.path.expanduser('~/node_modules/.bin')
 SUPPORTED_FILETYPES = ['png', 'svg']
 
 
-class NodeExecutor(object):
+class _NodeExecutor(object):
     """Class to execute vega/vega-lite conversion commands in nodejs
 
     Parameters
     ----------
     node_bin_dir : str
-        The directory containing binary executables installed by node
+        The directory containing binary executables installed by node.
+        If not specified, then ``npm root`` will be used to find it.
     verbose : bool (optional)
         If True (default) then print commands before executing them.
     """
-    def __init__(self, node_bin_dir=NODE_BIN_DIR, verbose=True):
+    def __init__(self, node_bin_dir=None, verbose=True):
         self.verbose = verbose
-        self.node_bin_dir = node_bin_dir
+        self.node_bin_dir = os.path.abspath(node_bin_dir or self.npm_root)
 
     def _exec(self, executable, inputfile, outputfile):
-        full_executable = os.path.join(NODE_BIN_DIR, executable)
+        full_executable = os.path.join(self.node_bin_dir, executable)
         if not os.path.exists(full_executable):
             raise ValueError('{0} not found'.format(full_executable))
         command = '{0} {1} > {2}'.format(full_executable,
@@ -59,9 +58,35 @@ class NodeExecutor(object):
     def vl2svg(self, inputfile, outputfile):
         self._chain('vl2vg', 'vg2svg', inputfile, outputfile)
 
+    @property
+    def npm_root(self):
+        rootdir = os.popen('npm root').read().strip()
+        if not os.path.exists(rootdir):
+            raise ValueError('npm root did not return a valid filename')
+        return os.path.join(rootdir, '.bin')
+
+    def savechart_available(self):
+        try:
+            root = self.npm_root
+        except:
+            return False
+        else:
+            root = root.strip()
+            if not os.path.exists(root):
+                return False
+            else:
+                L = os.listdir(root)
+                return ('vl2vg' in L and 'vg2png' in L and 'vg2svg' in L)
+
+
+def savechart_available(node_bin_dir=None):
+    node = _NodeExecutor(node_bin_dir=node_bin_dir)
+    return node.savechart_available()
+        
+
 
 def savechart(chart, filename, filetype=None,
-              node_bin_dir=NODE_BIN_DIR, verbose=True):
+              node_bin_dir=None, verbose=False):
     """EXPERIMENTAL means of saving a chart to png or svg
 
     Note that this requires several nodejs packages to be installed and
@@ -84,13 +109,11 @@ def savechart(chart, filename, filetype=None,
         The filetype to use (either 'svg' or 'png'). If not specified,
         it will be inferred from the filename.
     node_bin_dir : str
-        The directory containing binary executables installed by node
+        The directory containing binary executables installed by node.
+        If not specified, then ``npm root`` will be used to determine it.
     verbose : bool (optional)
         If True (default) then print commands before executing them.
     """
-    node = NodeExecutor(node_bin_dir=node_bin_dir,
-                        verbose=verbose)
-
     if filetype is None:
         base, ext = os.path.splitext(filename)
         filetype = ext[1:]
@@ -98,6 +121,12 @@ def savechart(chart, filename, filetype=None,
     if filetype not in SUPPORTED_FILETYPES:
         raise ValueError("Filetype {0} not valid: must be one of {1}"
                          "".format(filetype, SUPPORTED_FILETYPES))
+
+    node = _NodeExecutor(node_bin_dir=node_bin_dir,
+                         verbose=verbose)
+    if not node.savechart_available():
+        raise ValueError("Must install and configure nodejs tools "
+                         "to use savechart")
         
     with tempfile.NamedTemporaryFile(suffix='.json') as f:
         with open(f.name, 'w') as ff:

--- a/altair/utils/node.py
+++ b/altair/utils/node.py
@@ -1,0 +1,105 @@
+"""
+Utilities for using nodejs packages for generating png & svg
+"""
+from __future__ import print_function
+
+import os
+import tempfile
+import random
+
+
+__all__ = ['savechart']
+
+NODE_BIN_DIR = os.path.expanduser('~/node_modules/.bin')
+SUPPORTED_FILETYPES = ['png', 'svg']
+
+
+class NodeExecutor(object):
+    """Class to execute vega/vega-lite conversion commands in nodejs
+
+    Parameters
+    ----------
+    node_bin_dir : str
+        The directory containing binary executables installed by node
+    verbose : bool (optional)
+        If True (default) then print commands before executing them.
+    """
+    def __init__(self, node_bin_dir=NODE_BIN_DIR, verbose=True):
+        self.verbose = verbose
+        self.node_bin_dir = node_bin_dir
+
+    def _exec(self, executable, inputfile, outputfile):
+        full_executable = os.path.join(NODE_BIN_DIR, executable)
+        if not os.path.exists(full_executable):
+            raise ValueError('{0} not found'.format(full_executable))
+        command = '{0} {1} > {2}'.format(full_executable,
+                                         inputfile,
+                                         outputfile)
+        if self.verbose:
+            print('>', command)
+        os.system(command)
+
+    def _chain(self, executable1, executable2, inputfile, outputfile):
+        with tempfile.NamedTemporaryFile(suffix='.json') as f:
+            self._exec(executable1, inputfile, f.name)
+            self._exec(executable2, f.name, outputfile)
+
+    def vl2vg(self, inputfile, outputfile):
+        return _exec('vl2vg', inputfile, outputfile)
+
+    def vg2png(self, inputfile, outputfile):
+        return _exec('vl2vg', inputfile, outputfile)
+
+    def vg2svg(self, inputfile, outputfile):
+        return _exec('vl2vg', inputfile, outputfile)
+
+    def vl2png(self, inputfile, outputfile):
+        self._chain('vl2vg', 'vg2png', inputfile, outputfile)
+
+    def vl2svg(self, inputfile, outputfile):
+        self._chain('vl2vg', 'vg2svg', inputfile, outputfile)
+
+
+def savechart(chart, filename, filetype=None,
+              node_bin_dir=NODE_BIN_DIR, verbose=True):
+    """EXPERIMENTAL means of saving a chart to png or svg
+
+    Note that this requires several nodejs packages to be installed and
+    correctly configured. Before running this, you must use the node
+    package manager and install:
+
+        $ npm install canvas vega-lite
+
+    The binaries used here (``vl2vg``, ``vg2png``, ``vg2svg``) will be
+    installed in the node binary directory, which should be passed supplied
+    via the ``node_bin_dir`` argument.
+
+    Parameters
+    ----------
+    chart : Altair chart object
+        The chart to save
+    filename : str
+        The output filename
+    filetype : str (optional)
+        The filetype to use (either 'svg' or 'png'). If not specified,
+        it will be inferred from the filename.
+    node_bin_dir : str
+        The directory containing binary executables installed by node
+    verbose : bool (optional)
+        If True (default) then print commands before executing them.
+    """
+    node = NodeExecutor(node_bin_dir=node_bin_dir,
+                        verbose=verbose)
+
+    if filetype is None:
+        base, ext = os.path.splitext(filename)
+        filetype = ext[1:]
+
+    if filetype not in SUPPORTED_FILETYPES:
+        raise ValueError("Filetype {0} not valid: must be one of {1}"
+                         "".format(filetype, SUPPORTED_FILETYPES))
+        
+    with tempfile.NamedTemporaryFile(suffix='.json') as f:
+        with open(f.name, 'w') as ff:
+            ff.write(chart.to_json())
+        getattr(node, 'vl2' + filetype)(f.name, filename)

--- a/altair/utils/node.py
+++ b/altair/utils/node.py
@@ -36,12 +36,6 @@ class _NodeExecutor(object):
         full_executable = os.path.join(self.node_bin_dir, executable)
         if not os.path.exists(full_executable):
             raise ValueError('{0} not found'.format(full_executable))
-        #command = '{0} {1} > {2}'.format(full_executable,
-        #                                 inputfile,
-        #                                 outputfile)
-        #if self.verbose:
-        #    print('>', command)
-        #os.system(command)
         sp = subprocess.Popen([full_executable, inputfile],
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)
@@ -84,8 +78,6 @@ class _NodeExecutor(object):
         if hasattr(rootdir, 'decode'):
             # decode bytes in Pytho 3
             rootdir = rootdir.strip().decode('utf-8')
-        if not os.path.exists(rootdir):
-            raise ValueError('npm root did not return a valid directory')
         return os.path.join(rootdir, '.bin')
 
     def savechart_available(self):

--- a/altair/utils/node.py
+++ b/altair/utils/node.py
@@ -47,6 +47,9 @@ class _NodeExecutor(object):
             f.write(out)
 
     def _chain(self, executable1, executable2, inputfile, outputfile):
+        # stdin/stdout piping is not yet supported
+        # see https://github.com/vega/vega/issues/612
+        # We'll use temporary files instead.
         with tempfile.NamedTemporaryFile(suffix='.json') as f:
             self._exec(executable1, inputfile, f.name)
             self._exec(executable2, f.name, outputfile)
@@ -95,6 +98,7 @@ class _NodeExecutor(object):
 
 
 def savechart_available(node_bin_dir=None):
+    """Check if savechart() command is available on your system"""
     node = _NodeExecutor(node_bin_dir=node_bin_dir)
     return node.savechart_available()
         
@@ -102,17 +106,24 @@ def savechart_available(node_bin_dir=None):
 
 def savechart(chart, filename, filetype=None,
               node_bin_dir=None, verbose=False):
-    """EXPERIMENTAL means of saving a chart to png or svg
+    """**EXPERIMENTAL** function to save a chart to png or svg
 
     Note that this requires several nodejs packages to be installed and
-    correctly configured. Before running this, you must use the node
-    package manager and install:
+    correctly configured. Before running this, you must have nodejs on
+    your system and use the node package manager and install the ``canvas``
+    and ``vega-lite`` packages.
 
+    If you are using anaconda, you can set it up this way:
+
+        $ conda create -n node-env -c conda-forge python=2.7 nodejs altair
+        $ source activate node-env
         $ npm install canvas vega-lite
 
-    The binaries used here (``vl2vg``, ``vg2png``, ``vg2svg``) will be
-    installed in the node binary directory, which should be passed supplied
-    via the ``node_bin_dir`` argument.
+    The node binaries used here (``vl2vg``, ``vg2png``, ``vg2svg``) will be
+    installed in the node root directory, which should be automatically
+    detected by this function. If you have these nodejs packages installed
+    and this function doesn't work, try explicitly passing their path using
+    the ``node_bin_dir`` argument.
 
     Parameters
     ----------
@@ -143,6 +154,10 @@ def savechart(chart, filename, filetype=None,
         raise ValueError("Must install and configure nodejs tools "
                          "to use savechart")
         
+    
+    # stdin/stdout piping is not yet supported
+    # see https://github.com/vega/vega/issues/612
+    # We'll use temporary files instead.
     with tempfile.NamedTemporaryFile(suffix='.json') as f:
         with open(f.name, 'w') as ff:
             ff.write(chart.to_json())

--- a/altair/utils/tests/test_node.py
+++ b/altair/utils/tests/test_node.py
@@ -1,0 +1,42 @@
+import tempfile
+from xml.etree import ElementTree
+
+import pytest
+import pandas as pd
+
+from altair.utils.node import savechart, savechart_available
+from altair import Chart
+
+
+def consistent_with_png(filename):
+    """Check that the file has a header consistent with PNG"""
+    with open(filename, 'rb') as f:
+        arr = f.read()
+    return arr.startswith(b'\x89PNG\r\n')
+
+
+def consistent_with_svg(filename):
+    """Check that the file has a structure consistent with SVG"""
+    try:
+        e = ElementTree.parse(filename)
+    except ElementTree.ParseError:
+        return False
+    else:
+        keys = e.getroot().keys()
+        return set(keys) == {'width', 'version', 'class', 'height'}
+
+
+@pytest.mark.skipif(not savechart_available(),
+                    reason='node tools are not available')
+def test_savechart():
+    data = pd.DataFrame({'x': range(10),
+                         'y': range(10)})
+    chart = Chart(data).mark_point().encode(x='x', y='y')
+    
+    with tempfile.NamedTemporaryFile(suffix='.png') as f:
+        savechart(chart, f.name)
+        assert consistent_with_png(f.name)
+
+    with tempfile.NamedTemporaryFile(suffix='.svg') as f:
+        savechart(chart, f.name)
+        assert consistent_with_svg(f.name)

--- a/altair/utils/tests/test_node.py
+++ b/altair/utils/tests/test_node.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 import pytest
 import pandas as pd
 
-from altair.utils.node import savechart, savechart_available
+from altair.utils.node import savechart, savechart_available, NodeExecError
 from altair import Chart
 
 
@@ -34,9 +34,15 @@ def test_savechart():
     chart = Chart(data).mark_point().encode(x='x', y='y')
     
     with tempfile.NamedTemporaryFile(suffix='.png') as f:
-        savechart(chart, f.name)
+        try:
+            savechart(chart, f.name)
+        except NodeExecError:
+            pytest.skip('png failed due to improper nodejs setup')
         assert consistent_with_png(f.name)
 
     with tempfile.NamedTemporaryFile(suffix='.svg') as f:
-        savechart(chart, f.name)
+        try:
+            savechart(chart, f.name)
+        except NodeExecError:
+            pytest.skip('svg failed due to improper nodejs setup')
         assert consistent_with_svg(f.name)


### PR DESCRIPTION
This PR includes an experimental interface to save Altair charts to PNG or EPS from Python.

This requires several ``nodejs`` packages to be installed. With conda, the following works on my system:
```bash
$ conda install nodejs -c conda-forge
$ npm install canvas vega-lite  # requires python 2.7 for some reason
$ ls ~/node_modules/.bin/
vg2png  vg2svg  vl2png  vl2svg  vl2vg
```
If this works, then the script here should work:
```python
from altair import Chart
from altair.examples import load_example

chart = Chart.from_dict(load_example('area.json'))
savechart(chart, 'chart.png')
```
Then ``chart.png`` is a png of the chart.
