### PR TITLE
MAINT: Use en-dash in "UW–Madison"

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -32,7 +32,7 @@ affiliations:
     index: 1
   - name: California Polytechnic State University, San Luis Obispo
     index: 2
-  - name: University of Wisconsin, Madison
+  - name: University of Wisconsin--Madison
     index: 3
   - name: Florida State University
     index: 4


### PR DESCRIPTION
This changes the formatting for the formatting of UW–Madison.

``` diff
-  - name: University of Wisconsin, Madison
+  - name: University of Wisconsin--Madison
```

This is how it's supposed to be; even in their logo they use an en-dash:

<img width="300" alt="screen shot 2018-05-20 at 3 22 42 pm" src="https://user-images.githubusercontent.com/1320475/40283306-9e43ad28-5c6b-11e8-88f0-fc2eadecd137.png">

This is a small typo I noticed.