### PR TITLE
Revert deletion from author list

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -30,6 +30,9 @@ authors:
   - name: Ben Welsh
     orcid: 0000-0002-5200-7269
     affiliation: 5
+  - name: Scott Sievert
+    orcid: 0000-0002-4275-3452
+    affiliation: 6
     
 affiliations:
   - name: University of Washington
@@ -42,6 +45,8 @@ affiliations:
     index: 4
   - name: Los Angeles Times Data Desk
     index: 5
+  - name: University of Wisconsin--Madison
+    index: 6
 date: 07 August 2018
 bibliography: paper.bib
 ---


### PR DESCRIPTION
I was removed from the author list in https://github.com/altair-viz/altair/pull/394/commits/ca2fb1dcb90a983a2a4d7c20d6f6fd26d5eba1da#diff-e2778e7674f45b806282a9611faa7220L24. This PR reverts that change.

I think the deletion is a mistake, though I'm not certain (which is why I've added a WIP label). If it's not, could I have an explanation?